### PR TITLE
Fixed issue with short timeout for VLC startup

### DIFF
--- a/src/rpc/format.js
+++ b/src/rpc/format.js
@@ -49,7 +49,7 @@ module.exports = async (status) => {
   }
   
   const options = {
-    album: String(encodeURIComponent(meta.album))
+    album: meta.album
   }
 
   var appleresponse = await fetchArtworkApple(`${meta.title} ${display_artist}`);


### PR DESCRIPTION
This fixes an issue that I had for some time, where the first start up wouldn't work, because the VLC would start up too slow.
It is fixed by adding a delay and a retry when VLC is not found to be running.