### PR TITLE
Increased command verbosity in NodeCI workflow

### DIFF
--- a/.github/workflows/nodeci.yml
+++ b/.github/workflows/nodeci.yml
@@ -24,8 +24,8 @@ jobs:
           path: .
       - name: Package for Windows
         run: |
-          wget -nv -P .dist/win-x64 https://nodejs.org/download/release/latest/win-x64/node.exe
-          cp -r * .dist/win-x64/
+          wget -P .dist/win-x64 https://nodejs.org/download/release/latest/win-x64/node.exe
+          cp -rv * .dist/win-x64/
       - name: Archive production artifacts
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
I noticed the build workflow appeared to be stuck, so I increased verbosity of the commands to make debugging easier.
(Seems download speed when downloading `node.exe` has gotten much much slower for some reason, but perhaps it will get better again in the future.)